### PR TITLE
feat: add KubeStellar Console to Kubernetes & Containers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Servers for interacting with various cloud providers and services.
 
 Servers focused on container orchestration, Kubernetes management, and related tools.
 
+- [kubestellar/console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with built-in MCP server (kc-agent) for AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters
 - [ckreiling/mcp-server-docker](https://github.com/ckreiling/mcp-server-docker) - Docker integration for managing containers, images, volumes, and networks
 - [manusa/podman-mcp-server](https://github.com/manusa/podman-mcp-server) - MCP server for Podman container management with support for images, containers, volumes, pods, and networks
 - [manusa/kubernetes-mcp-server](https://github.com/manusa/kubernetes-mcp-server) - Powerful Kubernetes MCP server with OpenShift support and CRUD operations for any Kubernetes resource, plus specialized tools for cluster interaction


### PR DESCRIPTION
## What is this?

[KubeStellar Console](https://github.com/kubestellar/console) ships a native MCP server (`kc-agent`) that bridges AI assistants directly to multi-cluster Kubernetes environments. It enables natural-language queries, workload placement, and policy enforcement across clusters and clouds.

CNCF Sandbox project. Integrates with Argo, Kyverno, Istio, Prometheus, and 20+ more.

*Happy to adjust description or placement if needed.*